### PR TITLE
Deprecate FlowMachine::Factory

### DIFF
--- a/lib/flow_machine.rb
+++ b/lib/flow_machine.rb
@@ -2,6 +2,7 @@ $:.unshift(File.dirname(__FILE__))
 
 require "flow_machine/workflow"
 require "flow_machine/factory"
+require "flow_machine/workflow/factory_methods"
 require "flow_machine/workflow_state"
 require "flow_machine/callback"
 require "flow_machine/state_callback"

--- a/lib/flow_machine/factory.rb
+++ b/lib/flow_machine/factory.rb
@@ -1,27 +1,24 @@
 module FlowMachine
-  class Factory
+  # Deprecated in favor of calling these methods directly off of FlowMachine
+  # which are defined in FlowMachine::FactoryMethods
+  module Factory
     def self.workflow_for(object, options = {})
-      # If the object is enumerable, delegate. This allows workflow_for
-      # as shorthand
-      return workflow_for_collection(object, options) if object.respond_to?(:map)
-
-      klazz = workflow_class_for(object)
-      return nil unless klazz
-      klazz.new(object, options)
+      deprecate :workflow_for, :for
+      FlowMachine::Workflow.for(object, options)
     end
 
     def self.workflow_for_collection(collection, options = {})
-      collection.map { |item| workflow_for(item, options) }
+      deprecate :workflow_for_collection, :for_collection
+      FlowMachine::Workflow.for_collection(collection, options)
     end
 
     def self.workflow_class_for(object_or_class)
-      if object_or_class.is_a? Class
-        "#{object_or_class.name}Workflow".constantize
-      else
-        workflow_class_for(object_or_class.class)
-      end
-    rescue NameError # if the workflow class doesn't exist
-      nil
+      deprecate :workflow_class_for, :class_for
+      FlowMachine::Workflow.class_for(object_or_class)
+    end
+
+    def self.deprecate(old_method_name, new_method_name)
+      warn "FlowMachine::Factory.#{old_method_name} is deprecated. Use FlowMachine::Workflow.#{new_method_name} instead."
     end
   end
 end

--- a/lib/flow_machine/version.rb
+++ b/lib/flow_machine/version.rb
@@ -1,3 +1,3 @@
 module FlowMachine
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/lib/flow_machine/workflow.rb
+++ b/lib/flow_machine/workflow.rb
@@ -1,8 +1,11 @@
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/try"
+require "flow_machine/workflow/factory_methods"
 
 module FlowMachine
   module Workflow
+    extend FlowMachine::FactoryMethods
+
     def self.included(base)
       base.extend(ClassMethods)
       base.send(:attr_reader, :object)

--- a/lib/flow_machine/workflow/factory_methods.rb
+++ b/lib/flow_machine/workflow/factory_methods.rb
@@ -1,0 +1,28 @@
+# These methods are extended in the base FlowMachine module
+module FlowMachine
+  module FactoryMethods
+    def for(object, options = {})
+      # If the object is enumerable, delegate. This allows workflow_for
+      # as shorthand
+      return for_collection(object, options) if object.respond_to?(:map)
+
+      klazz = class_for(object)
+      return nil unless klazz
+      klazz.new(object, options)
+    end
+
+    def for_collection(collection, options = {})
+      collection.map { |item| self.for(item, options) }
+    end
+
+    def class_for(object_or_class)
+      if object_or_class.is_a? Class
+        "#{object_or_class.name}Workflow".constantize
+      else
+        self.class_for(object_or_class.class)
+      end
+    rescue NameError # if the workflow class doesn't exist
+      nil
+    end
+  end
+end

--- a/spec/flow_machine/deprecated_factory_methods_spec.rb
+++ b/spec/flow_machine/deprecated_factory_methods_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe FlowMachine::Factory do
+  class TestClass; end
+
+  class TestClassWorkflow
+    include FlowMachine::Workflow
+  end
+
+  describe '.workflow_class_for' do
+    subject(:workflow_class) { described_class.workflow_class_for(target) }
+    before { expect(described_class).to receive(:deprecate) }
+
+    describe 'with a class' do
+      let(:target) { TestClass }
+      it { should eq(TestClassWorkflow) }
+    end
+
+    describe 'with an object' do
+      let(:target) { TestClass.new }
+      it { should eq(TestClassWorkflow) }
+    end
+  end
+
+  describe '.workflow_for' do
+    subject(:workflow) { described_class.workflow_for(target) }
+    before { expect(described_class).to receive(:deprecate) }
+
+    class SomeNewClass; end
+
+    describe 'not found' do
+      let(:target) { SomeNewClass.new }
+      it { should be_nil }
+    end
+
+    describe 'with an object' do
+      let(:target) { TestClass.new }
+      it { should be_an_instance_of(TestClassWorkflow) }
+      its(:object) { should eq(target) }
+    end
+
+    describe 'with an array of objects' do
+      let(:target) { [TestClass.new, TestClass.new] }
+      it { should match [an_instance_of(TestClassWorkflow), an_instance_of(TestClassWorkflow)] }
+    end
+  end
+
+  describe '.workflow_for_collection' do
+    subject(:result) { described_class.workflow_for_collection(target) }
+    before { expect(described_class).to receive(:deprecate) }
+
+    let(:target) { [TestClass.new, TestClass.new] }
+    it { should match [an_instance_of(TestClassWorkflow), an_instance_of(TestClassWorkflow)] }
+  end
+end

--- a/spec/flow_machine/factory_methods_spec.rb
+++ b/spec/flow_machine/factory_methods_spec.rb
@@ -1,12 +1,12 @@
-RSpec.describe FlowMachine::Factory do
+RSpec.describe FlowMachine::Workflow do
   class TestClass; end
 
   class TestClassWorkflow
     include FlowMachine::Workflow
   end
 
-  describe '.workflow_class_for' do
-    subject(:workflow_class) { described_class.workflow_class_for(target) }
+  describe '.class_for' do
+    subject(:workflow_class) { described_class.class_for(target) }
 
     describe 'with a class' do
       let(:target) { TestClass }
@@ -19,8 +19,8 @@ RSpec.describe FlowMachine::Factory do
     end
   end
 
-  describe '.workflow_for' do
-    subject(:workflow) { described_class.workflow_for(target) }
+  describe '.for' do
+    subject(:workflow) { described_class.for(target) }
     class SomeNewClass; end
 
     describe 'not found' do
@@ -41,7 +41,7 @@ RSpec.describe FlowMachine::Factory do
   end
 
   describe '.workflow_for_collection' do
-    subject(:result) { described_class.workflow_for_collection(target) }
+    subject(:result) { described_class.for_collection(target) }
     let(:target) { [TestClass.new, TestClass.new] }
     it { should match [an_instance_of(TestClassWorkflow), an_instance_of(TestClassWorkflow)] }
   end


### PR DESCRIPTION
The methods should now be called directly off of the FlowMachine::Workflow module as `for` vs `FlowMachine.workflow_for`.

Bump version to 0.1.1

Addresses issue #4 