### PR TITLE
[#10] Add a guard_error to the workflow when attempting invalid events

### DIFF
--- a/lib/flow_machine/workflow.rb
+++ b/lib/flow_machine/workflow.rb
@@ -91,10 +91,16 @@ module FlowMachine
       end
 
       # Defines an instance method on Workflow that delegates to the
-      # current state, but only if the current_state implements the method
+      # current state. If the current state does not support the method, then
+      # add an :invalid_event error to the guard_errors.
       def define_state_method(method_name)
         define_method method_name do |*args|
-          current_state.respond_to?(method_name) && current_state.send(method_name, *args)
+          if current_state.respond_to?(method_name)
+            current_state.send(method_name, *args)
+          else
+            self.guard_errors = [:invalid_event]
+            false
+          end
         end
       end
 
@@ -114,7 +120,7 @@ module FlowMachine
 
     # extend Forwardable
     # def_delegators :current_state, :guard_errors
-    delegate :guard_errors, to: :current_state
+    delegate :guard_errors, :guard_errors=, to: :current_state
 
     def initialize(object, options = {})
       @object = object

--- a/spec/flow_machine/workflow_state_spec.rb
+++ b/spec/flow_machine/workflow_state_spec.rb
@@ -42,12 +42,13 @@ RSpec.describe FlowMachine::WorkflowState do
     end
   end
 
-  describe 'events' do
+  describe 'invalid transitions' do
     let(:state_class2) do
       Class.new(described_class) do
         def self.state_name; :test2; end
       end
     end
+
     before :each do
       state_class.event(:event1) { transition to: :test2 }
       workflow_class.refresh_state_methods!
@@ -57,6 +58,18 @@ RSpec.describe FlowMachine::WorkflowState do
     it 'returns false when trying to transition to the current state' do
       expect(object).to receive(:state).and_return :test2
       expect(workflow.event1).to be false
+    end
+
+    it 'sets an invalid_event error when trying to transition to the curent state' do
+      expect(object).to receive(:state).and_return :test2
+      workflow.event1
+      expect(workflow.guard_errors).to eq([:invalid_event])
+    end
+
+    it 'sets an invalid_event error when trying to may to the current state' do
+      expect(object).to receive(:state).and_return :test2
+      expect(workflow).not_to be_may_event1
+      expect(workflow.guard_errors).to eq([:invalid_event])
     end
   end
 
@@ -70,7 +83,7 @@ RSpec.describe FlowMachine::WorkflowState do
         state.event1
       end
 
-      context 'may?' do
+      describe 'may?' do
         it 'is able to transition if the guard returns true' do
           expect(state).to receive(:guard1?).and_return true
           expect(state.may_event1?).to be true


### PR DESCRIPTION
When calling `#may_event?`, `#event`, or `#event!`, if the event is not
supported by the current state, add `:invalid_event` to the `guard_errors`.

I considered `raise NoMethodError.new("#{method_name} is an invalid
transition from #{current_state.name}”)`, but has the following downsides:

1. `may_event?` should not raise an error because it's a basic predicate
and in my opinion should simply return `false` if it can't do what you're
asking. Changing the code to maintain this behavior while raising an
error on the transition would require significant refactoring.

2. I don’t like raising exceptions when they’re likely to be triggered by
user actions, but fully support them when triggered by developer mistakes.
Especially in the case of `may_event?`, I think this error could lead to
user-visible errors (i.e. 500 errors).

3. Raising an error on this would be a breaking change. There are likely
few applications using this gem and it's a 0.X release, but it's still
a concern. I did my applications' specs against the `raise` version and
while everything was green, I did see the following issue in practice (we
use current state to decide which next states to show buttons for instead
of using `may_event?`).

3. Considering the case where this is used in a web application: I have
two tabs of the same object with a button to transition to the next state.
On the first tab, I click the button and it transitions successfully. I switch
to the second tab and click the transition button. With the `raise` version
I get a 500 error. This feels like a bad user experience. The controller action
is essentially (with some `before_action`s and I18n):

    ```
  def publish
    workflow = FlowMachine::Workflow.for(resource).publish!(current_user: current_user)
    if workflow.publish!
      redirect_to resource, notice: "The post was published"
    else
      flash[:now] = "The post could not be published"
      render :show
    end
    ```

  If messaging is important in your case, the `else` case could be changed to
  have a reason based on the `workflow.guard_errors`. This method also prevents
  a similar multi-tab case of one tab changing things that make a `guard` method
  (or `ActiveModel` validation) invalid. We don't do anything fancy, but you
  could easily change the `flash` message to be dynamic based on the `guard_errors`
  or `ActiveModel#errors`.

@lucasmazza, does this meet your needs?

I'll also want to update the documentation, and possibly do some refactoring of the tests (trying to fit this into the existing specs felt somewhat awkward), but I want to make sure this meets your use case before spending more time.