### PR TITLE
Upgrade RSpec to 3.5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   ruby:
-    version: "2.2"
+    version: "2.3.1"

--- a/flow_machine.gemspec
+++ b/flow_machine.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency 'activesupport', '>= 3.2'
-  s.add_development_dependency "rspec", '~> 3.1.0'
+  s.add_development_dependency "rspec", '~> 3.5.0'
   s.add_development_dependency "rspec-its"
 end

--- a/spec/flow_machine/workflow_spec.rb
+++ b/spec/flow_machine/workflow_spec.rb
@@ -121,8 +121,7 @@ RSpec.describe FlowMachine::Workflow do
 
       it 'does not call for invalid states' do
         expect(workflow).not_to receive(:after_transition_callback)
-        # Will throw an ArgumentError for invalid state
-        expect { workflow.transition to: :invalid_state }.to raise_error
+        expect { workflow.transition to: :invalid_state }.to raise_error(ArgumentError)
       end
 
       it 'does not call for ending in the same state' do


### PR DESCRIPTION
Goal is to eventually remove dependency on ActiveSupport (#3), but for now, ActiveSupport 5.0.0.1 requires Ruby 2.2.2+, so test against that. This is only really a testing problem here: we're only using `try` and `delegate` from ActiveSupport, which are available 3.2+.