### PR TITLE
Fix `create_scopes_on` use of hardcoded state method

### DIFF
--- a/lib/flow_machine/workflow.rb
+++ b/lib/flow_machine/workflow.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/try"
 require "flow_machine/workflow/factory_methods"
+require "flow_machine/workflow/model_extension"
 
 module FlowMachine
   module Workflow
@@ -8,31 +9,11 @@ module FlowMachine
 
     def self.included(base)
       base.extend(ClassMethods)
+      base.extend(ModelExtension)
       base.send(:attr_reader, :object)
     end
 
     module ClassMethods
-      # resolves to
-      # class Model
-      #   def self.published
-      #     where(status: 'published')
-      #   end
-      #
-      #   def published?
-      #     self.status == 'published'
-      #   end
-      # end
-      def create_scopes_on(content_class)
-        self.state_names.each do |status|
-          content_class.singleton_class.send(:define_method, status) do
-            where(status: status)
-          end
-
-          content_class.send(:define_method, "#{status}?") do
-            self.status == status
-          end
-        end
-      end
 
       attr_accessor :callbacks
 

--- a/lib/flow_machine/workflow/model_extension.rb
+++ b/lib/flow_machine/workflow/model_extension.rb
@@ -1,0 +1,32 @@
+module FlowMachine
+  module Workflow
+    module ModelExtension
+      # resolves to
+      # class Model
+      #   def self.published
+      #     where(status: 'published')
+      #   end
+      #
+      #   def published?
+      #     self.status == 'published'
+      #   end
+      # end
+      def create_scopes_on(content_class)
+        state_method = self.state_method
+        state_names.each do |status|
+          # Don't add the scope classes if `where` is not defined since it means
+          # you're likely not in a ORM class.
+          if content_class.respond_to?(:where)
+            content_class.singleton_class.send(:define_method, status) do
+              where(state_method => status)
+            end
+          end
+
+          content_class.send(:define_method, "#{status}?") do
+            public_send(state_method) == status
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/flow_machine/workflow/model_extension_spec.rb
+++ b/spec/flow_machine/workflow/model_extension_spec.rb
@@ -1,0 +1,55 @@
+require 'ostruct'
+
+RSpec.describe FlowMachine::Workflow::ModelExtension do
+  class Test1State < FlowMachine::WorkflowState
+  end
+
+  class Test2State < FlowMachine::WorkflowState
+  end
+
+  class TestWorkflow
+    include FlowMachine::Workflow
+    state Test1State
+    state Test2State
+  end
+
+  describe '.create_scopes_on' do
+    class PersistedModel < Struct.new(:state)
+      def self.where(opts)
+        [new(opts[:state])]
+      end
+
+      TestWorkflow.create_scopes_on(self)
+    end
+
+    class UnPersistedModel < Struct.new(:state)
+      TestWorkflow.create_scopes_on(self)
+    end
+
+    it 'adds the predicate model for state 1' do
+      expect(PersistedModel.new('test1')).to be_test1
+      expect(PersistedModel.new('test2')).not_to be_test1
+    end
+
+    it 'adds the predicate model for state 2' do
+      expect(PersistedModel.new('test1')).not_to be_test2
+      expect(PersistedModel.new('test2')).to be_test2
+    end
+
+    it 'adds a scope for test1' do
+      expect(PersistedModel.test1).to be_an(Array)
+      expect(PersistedModel.test1).to be_one
+      expect(PersistedModel.test1.first).to eq(PersistedModel.new('test1'))
+    end
+
+    it 'adds a scope for test2' do
+      expect(PersistedModel.test2).to be_an(Array)
+      expect(PersistedModel.test2).to be_one
+      expect(PersistedModel.test2.first).to eq(PersistedModel.new('test2'))
+    end
+
+    it 'does not add scopes if where is not defined' do
+      expect(UnPersistedModel).not_to respond_to(:test1)
+    end
+  end
+end


### PR DESCRIPTION
Before, it would always use `status` as the state. Now use what was configured
as `state_attribute`.